### PR TITLE
Make _neighbours lists as pointer members.

### DIFF
--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -33,7 +33,7 @@ Entity::~Entity() {
     delete _neighbours;
 }
 
-Entity::Entity(const Entity& other) {
+Entity::Entity(const Entity &other) {
     _id = other._id;
     _pos = other._pos;
     _vel = other._vel;
@@ -47,6 +47,8 @@ Entity::Entity(const Entity& other) {
     _dt = other._dt;
     _super_type = other._super_type;
     _type = other._type;
+    _neighbours = new QList<QWeakPointer<Entity>>;
+    _visible_neighbours = new QList<QWeakPointer<Entity>>;
 }
 
 Entity::Entity(const QVector2D &position, const QVector2D &init_speed) {

--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -26,8 +26,11 @@ QString Entity::super_type_string = "Undefined";
 QString Entity::type_string = "Undefined";
 
 Entity::~Entity() {
-    _visible_neighbours.clear();
-    _neighbours.clear();
+    _visible_neighbours->clear();
+    _neighbours->clear();
+
+    delete _visible_neighbours;
+    delete _neighbours;
 }
 
 Entity::Entity(const Entity& other) {
@@ -116,13 +119,13 @@ Entity::size() const {
     return _size;
 }
 
-QList<QWeakPointer<Entity>>
-Entity::neigbours() const {
+QList<QWeakPointer<Entity>> *
+Entity::neighbours() const {
     return _neighbours;
 }
 
-QList<QWeakPointer<Entity>>
-Entity::visible_neigbours() const {
+QList<QWeakPointer<Entity>> *
+Entity::visible_neighbours() const {
     return _visible_neighbours;
 }
 

--- a/src/entity/entity.h
+++ b/src/entity/entity.h
@@ -37,7 +37,6 @@ class Entity : public QGraphicsItem {
     Entity() = default;
 
     //! Copy Constructor
-    // TODO : decide what to do with _neighbours and _visible_neighbours
     Entity(const Entity& other);
 
     //! Default move Constructor
@@ -91,8 +90,8 @@ class Entity : public QGraphicsItem {
     QString type_name() const;
     QString super_type_name() const;
 
-    QList<QWeakPointer<Entity>> neigbours() const;
-    QList<QWeakPointer<Entity>> visible_neigbours() const;
+    QList<QWeakPointer<Entity>> *neighbours() const;
+    QList<QWeakPointer<Entity>> *visible_neighbours() const;
 
     void set_time_step(float dt);
 
@@ -136,8 +135,8 @@ class Entity : public QGraphicsItem {
     QColor _color{200, 0, 0, 255};  //!< Color
     float _life{100};
     QVector2D _size{20, 20};
-    QList<QWeakPointer<Entity>> _neighbours{};
-    QList<QWeakPointer<Entity>> _visible_neighbours{};
+    QList<QWeakPointer<Entity>> *_neighbours{nullptr};
+    QList<QWeakPointer<Entity>> *_visible_neighbours{nullptr};
 
     float _dt{1};  //<! Time-step given by World
 

--- a/src/entity/entity.h
+++ b/src/entity/entity.h
@@ -135,8 +135,8 @@ class Entity : public QGraphicsItem {
     QColor _color{200, 0, 0, 255};  //!< Color
     float _life{100};
     QVector2D _size{20, 20};
-    QList<QWeakPointer<Entity>> *_neighbours{nullptr};
-    QList<QWeakPointer<Entity>> *_visible_neighbours{nullptr};
+    QList<QWeakPointer<Entity>> *_neighbours{new QList<QWeakPointer<Entity>>};
+    QList<QWeakPointer<Entity>> *_visible_neighbours{new QList<QWeakPointer<Entity>>};
 
     float _dt{1};  //<! Time-step given by World
 


### PR DESCRIPTION
Now Entity size is known at compile time and heap will hold the
references to the neighbours for us.

Related to #1