### PR TITLE
World wrap around

### DIFF
--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -215,8 +215,32 @@ Entity::is_visible(const QPointF &world_pos) const {
         return false;
     }
 
-    // FIXME : Needs a fix when world wraps around
-    return vision().containsPoint(mapFromScene(world_pos), Qt::OddEvenFill);
+    if (!parent_world()->wrap_around()) {
+        return vision().containsPoint(mapFromScene(world_pos), Qt::OddEvenFill);
+    } else { /* Test all "fictive" positions around the borders, return true if
+                it exists */
+        QVector2D fictive_offset;
+        if (world_pos.x() < 0 && _pos.x() >= 0) {
+            fictive_offset += QVector2D(parent_world()->size().x(), 0);
+        }
+        if (world_pos.x() >= 0 && _pos.x() < 0) {
+            fictive_offset -= QVector2D(parent_world()->size().x(), 0);
+        }
+        if (world_pos.y() < 0 && _pos.y() >= 0) {
+            fictive_offset += QVector2D(0, parent_world()->size().y());
+        }
+        if (world_pos.y() >= 0 && _pos.y() < 0) {
+            fictive_offset -= QVector2D(0, parent_world()->size().y());
+        }
+
+        QPointF fictive_world_pos;
+        fictive_world_pos.setX(world_pos.x() +
+                               static_cast<double>(fictive_offset.x()));
+        fictive_world_pos.setY(world_pos.y() +
+                               static_cast<double>(fictive_offset.y()));
+        return vision().containsPoint(mapFromScene(fictive_world_pos),
+                                      Qt::OddEvenFill);
+    }
 }
 
 const QPolygonF &

--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -174,6 +174,7 @@ void
 Entity::update() {
     _vel += _acc * time_step();
     _pos += _vel * time_step();
+    parent_world()->fix_position_for_wrap_around(_pos);
     _acc *= 0;
     update_scene_pos();
 }

--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -203,6 +203,9 @@ Entity::update_neighbourhood() {
 
     for (auto &&item : parent_world()->items()) {
         _neighbours->append(dynamic_cast<const Entity *>(item));
+        if (is_visible(item->pos())) {
+            _visible_neighbours->append(dynamic_cast<const Entity*>(item));
+        }
     }
 }
 
@@ -232,6 +235,12 @@ Entity::update_scene_pos() {
 
 QRectF
 Entity::boundingRect() const {
+    if (!_vision.isNull() && _show_vision && !vision().isEmpty()) {
+        // We add margins to the bounding Rect of Vision so it extends behind
+        // itself, theoretically covering the back of the Ant
+        return _vision->boundingRect().marginsAdded(
+            QMarginsF(0, 0, 0, _vision->boundingRect().height()));
+    }
     return QRectF(-_size.x() / 2, -_size.y() / 2, _size.x(), _size.y());
 }
 

--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -30,6 +30,7 @@
 Entity::~Entity() {
     _visible_neighbours->clear();
     _neighbours->clear();
+    _vision.clear();
 
     delete _visible_neighbours;
     delete _neighbours;
@@ -203,6 +204,21 @@ Entity::update_neighbourhood() {
     for (auto &&item : parent_world()->items()) {
         _neighbours->append(dynamic_cast<const Entity *>(item));
     }
+}
+
+bool
+Entity::is_visible(const QPointF &world_pos) const {
+    if (_vision.isNull()) {
+        return false;
+    }
+
+    // FIXME : Needs a fix when world wraps around
+    return vision().containsPoint(mapFromScene(world_pos), Qt::OddEvenFill);
+}
+
+const QPolygonF &
+Entity::vision() const {
+    return *_vision.data();
 }
 
 void

--- a/src/entity/entity.h
+++ b/src/entity/entity.h
@@ -45,7 +45,7 @@ class Entity : public QGraphicsItem {
            const QVector2D &init_speed = QVector2D(0, 0));
 
     /////////////// Destructor
-    virtual ~Entity();
+    virtual ~Entity() override;
 
     /////////////// Misc. Methods
 
@@ -145,6 +145,20 @@ class Entity : public QGraphicsItem {
     //! Arbitrarily set size of entity
     void set_size(QVector2D new_size);
 
+    //! Return a constant reference to the vision of Entity
+    /*! _vision should be non-null when we call this (although it
+     * can point to an empty QPolygonF)
+     */
+    const QPolygonF &vision() const;
+
+    /*!
+     * \brief is_visible return true if this world_pos is visible by Entity
+     * \param [in] world_pos the position in World coordinates
+     * \return true if the position is in _vision.
+     * Note : the method handled properly the cases where _vision points nowhere
+     */
+    virtual bool is_visible(const QPointF &world_pos) const;
+
     inline bool
     toggle_show_vision() {
         _show_vision = !_show_vision;
@@ -187,17 +201,17 @@ class Entity : public QGraphicsItem {
     QString _super_type{"Undefined"};
     QString _type{"Undefined"};
 
+    /* TODO : consider a defaut construction of _vision.
+     * Currently we prefer keeping returning a const reference to QPolygonF
+     * in vision(), to avoid copies. However we are not able to simply return
+     * an empty QPolygonF built on stack with this signature.
+     */
     //! Vision polygon in Item coord
     /*! We look forward in the -y direction
      * all Entities must be centered on (0,0) for _vision to work
      *
      * _vision should not be left null, it WILL break when we use the
      * vision() getter in other functionnalities
-     *
-     * TODO : consider a defaut construction of _vision.
-     * Currently we prefer keeping returning a const reference to QPolygonF
-     * in vision(), to avoid copies. However we are not able to simply return
-     * an empty QPolygonF built on stack with this signature.
      */
     QSharedPointer<QPolygonF> _vision{};
 };

--- a/src/entity/entity.h
+++ b/src/entity/entity.h
@@ -49,7 +49,7 @@ class Entity : public QGraphicsItem {
 
     /////////////// Misc. Methods
 
-    //! Give an approximate bounding rectangle for the Ant
+    //! Give an approximate bounding rectangle for the Entity
     virtual QRectF boundingRect() const override;
 
     //! Give the shape of the Entity for collision detection
@@ -150,6 +150,11 @@ class Entity : public QGraphicsItem {
      * can point to an empty QPolygonF)
      */
     const QPolygonF &vision() const;
+
+    void set_vision(const QSharedPointer<QPolygonF>& new_vision) {
+        _vision.clear();
+        _vision = QSharedPointer<QPolygonF>(new_vision);
+    }
 
     /*!
      * \brief is_visible return true if this world_pos is visible by Entity

--- a/src/entity/living_entity.cpp
+++ b/src/entity/living_entity.cpp
@@ -46,12 +46,14 @@ LivingEntity::update_neighbourhood() {
     }
 }
 
+// TODO : This method should go up in Entity base class
 bool
 LivingEntity::is_visible(const QPointF &world_pos) const {
     if (_vision.isNull()) {
         return false;
     }
 
+    // FIXME : Needs a fix when world wraps around
     return vision().containsPoint(mapFromScene(world_pos), Qt::OddEvenFill);
 }
 

--- a/src/entity/living_entity.cpp
+++ b/src/entity/living_entity.cpp
@@ -34,25 +34,3 @@ void
 LivingEntity::decide_acceleration() {
     _acc = QVector2D(0.0f, 0.0f);
 }
-
-void
-LivingEntity::update_neighbourhood() {
-    Entity::update_neighbourhood();
-
-    for (auto &&item : *_neighbours) {
-        if (is_visible(item->pos())) {
-            _visible_neighbours->append(item);
-        }
-    }
-}
-
-QRectF
-LivingEntity::boundingRect() const {
-    if (_show_vision && !vision().isEmpty()) {
-        // We add margins to the bounding Rect of Vision so it extends behind
-        // itself, theoretically covering the back of the Ant
-        return _vision->boundingRect().marginsAdded(
-            QMarginsF(0, 0, 0, _vision->boundingRect().height()));
-    }
-    return Entity::boundingRect();
-}

--- a/src/entity/living_entity.cpp
+++ b/src/entity/living_entity.cpp
@@ -46,17 +46,6 @@ LivingEntity::update_neighbourhood() {
     }
 }
 
-// TODO : This method should go up in Entity base class
-bool
-LivingEntity::is_visible(const QPointF &world_pos) const {
-    if (_vision.isNull()) {
-        return false;
-    }
-
-    // FIXME : Needs a fix when world wraps around
-    return vision().containsPoint(mapFromScene(world_pos), Qt::OddEvenFill);
-}
-
 QRectF
 LivingEntity::boundingRect() const {
     if (_show_vision && !vision().isEmpty()) {
@@ -66,9 +55,4 @@ LivingEntity::boundingRect() const {
             QMarginsF(0, 0, 0, _vision->boundingRect().height()));
     }
     return Entity::boundingRect();
-}
-
-const QPolygonF &
-LivingEntity::vision() const {
-    return *_vision.data();
 }

--- a/src/entity/living_entity.h
+++ b/src/entity/living_entity.h
@@ -30,12 +30,6 @@ class LivingEntity : public Entity {
     LivingEntity(const QVector2D &position,
                  const QVector2D &init_speed = QVector2D(0, 0));
 
-    //! Override necessary because of _vision
-    void update_neighbourhood() override;
-
-    //! Override necessary because of _vision
-    virtual QRectF boundingRect() const override;
-
     inline void
     set_vision(QSharedPointer<QPolygonF> new_vision) {
         // operator= handles the decrement of older reference count

--- a/src/entity/living_entity.h
+++ b/src/entity/living_entity.h
@@ -46,17 +46,9 @@ class LivingEntity : public Entity {
         set_vision(new_vision.toStrongRef());
     }
 
-    //! Return a constant reference to the vision of LivingEntity
-    /*! _vision should be non-null when we call this (although it
-     * can point to an empty QPolygonF)
-     */
-    const QPolygonF &vision() const;
-    //! Return true if this world_pos is visible by LivingEntity
-    virtual bool is_visible(const QPointF &world_pos) const;
+    virtual void decide_acceleration() override;
 
-    virtual void decide_acceleration();
-
-    virtual ~LivingEntity() { _vision.clear(); }
+    virtual ~LivingEntity() override {}
 };
 
 #endif  // _ENTITY_LIVING_ENTITY_H_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,7 @@ main(int argc, char* argv[]) {
               << EMERGENCE_VERSION_MINOR << std::endl;
     std::cout << "\n"
                  "*********** Usage ************\n"
+                 "Hit [W] to toggle finite/infinite World (wrapping around)\n"
                  "Hit [V] to toggle the vision of Entities in the window\n"
                  "Hit [D] to disable the vision of Entities in the window\n"
                  "Hit [E] to enable the vision of Entities in the window\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,8 +40,7 @@ main(int argc, char* argv[]) {
                  "Hit [D] to disable the vision of Entities in the window\n"
                  "Hit [E] to enable the vision of Entities in the window\n"
                  "Hit [A] to add an Ant in a random position within view\n"
-                 "Hit [F] to add Food in a random position within view\n"
-                 ;
+                 "Hit [F] to add Food in a random position within view\n";
 
     srand(static_cast<unsigned>(time(nullptr)));
 
@@ -70,7 +69,8 @@ main(int argc, char* argv[]) {
     QTimer timer;
     QObject::connect(&timer, SIGNAL(timeout()), mainWin.get_view()->get_scene(),
                      SLOT(advance()));
-    timer.start((int)(1000.0 * mainWin.get_view()->get_scene()->time_step()));
+    timer.start(static_cast<int>(1000.0f *
+                                 mainWin.get_view()->get_scene()->time_step()));
 
     return app.exec();
 }

--- a/src/ui/world_view.cpp
+++ b/src/ui/world_view.cpp
@@ -59,10 +59,10 @@ WorldView::keyPressEvent(QKeyEvent* event) {
      * widget.
      */
 
-    float dx = QRandomGenerator::global()->bounded(sceneRect().width());
-    float dy = QRandomGenerator::global()->bounded(sceneRect().height());
-    float pos_x = sceneRect().x() + dx;
-    float pos_y = sceneRect().y() + dy;
+    double dx = QRandomGenerator::global()->bounded(sceneRect().width());
+    double dy = QRandomGenerator::global()->bounded(sceneRect().height());
+    double pos_x = sceneRect().x() + dx;
+    double pos_y = sceneRect().y() + dy;
 
     switch (event->key()) {
         case Qt::Key_A:
@@ -94,7 +94,7 @@ WorldView::keyPressEvent(QKeyEvent* event) {
 }
 
 void
-WorldView::change_scale(float scale_factor) {
+WorldView::change_scale(double scale_factor) {
     xy_scale *= scale_factor;
     scale(scale_factor, scale_factor);
     return;

--- a/src/ui/world_view.cpp
+++ b/src/ui/world_view.cpp
@@ -91,6 +91,10 @@ WorldView::keyPressEvent(QKeyEvent* event) {
             emit key_handled("(E) Enable vision drawing - Revert with D");
             get_scene()->enable_all_visions();
             break;
+        case Qt::Key_W:
+            emit key_handled("(W) Toggle World Wrap Around");
+            get_scene()->toggle_wrap_around();
+            break;
         default:
             emit key_handled("User pressed " + event->text() +
                              " - NOT HANDLED");

--- a/src/ui/world_view.cpp
+++ b/src/ui/world_view.cpp
@@ -61,19 +61,23 @@ WorldView::keyPressEvent(QKeyEvent* event) {
 
     double dx = QRandomGenerator::global()->bounded(sceneRect().width());
     double dy = QRandomGenerator::global()->bounded(sceneRect().height());
-    double pos_x = sceneRect().x() + dx;
-    double pos_y = sceneRect().y() + dy;
+    double random_pos_x = sceneRect().x() + dx;
+    double random_pos_y = sceneRect().y() + dy;
 
     switch (event->key()) {
         case Qt::Key_A:
-            emit key_handled(
-                QString("Adding an Ant in (%1;%2)").arg(pos_x).arg(pos_y));
-            get_scene()->add_entity("Living", "Ant", QVector2D(pos_x, pos_y));
+            emit key_handled(QString("Adding an Ant in (%1;%2)")
+                                 .arg(random_pos_x)
+                                 .arg(random_pos_y));
+            get_scene()->add_entity("Living", "Ant",
+                                    QVector2D(random_pos_x, random_pos_y));
             break;
         case Qt::Key_F:
-            emit key_handled(
-                QString("Adding Food in (%1;%2)").arg(pos_x).arg(pos_y));
-            get_scene()->add_entity("Inert", "Food", QVector2D(pos_x, pos_y));
+            emit key_handled(QString("Adding Food in (%1;%2)")
+                                 .arg(random_pos_x)
+                                 .arg(random_pos_y));
+            get_scene()->add_entity("Inert", "Food",
+                                    QVector2D(random_pos_x, random_pos_y));
             break;
         case Qt::Key_V:
             emit key_handled("(V) Toggle vision drawing");

--- a/src/ui/world_view.h
+++ b/src/ui/world_view.h
@@ -46,7 +46,7 @@ class WorldView : public QGraphicsView {
     void keyPressEvent(QKeyEvent* event) override;
 
  public slots:
-    void change_scale(float scale_factor);
+    void change_scale(double scale_factor);
     void reset_scale();
     void scale_to_see_all_items();
 
@@ -57,7 +57,7 @@ class WorldView : public QGraphicsView {
  protected:
  private:
     QBrush background{};
-    float xy_scale{1.0};
+    double xy_scale{1.0};
 };
 
 #endif  // _UI_WORLD_VIEW_H_

--- a/src/world/world.cpp
+++ b/src/world/world.cpp
@@ -62,16 +62,16 @@ World::fix_position_for_wrap_around(QVector2D &old_position) const {
     }
 
     while (old_position.x() < -_size.x() / 2) {
-        old_position[0] += _size.x();
+        old_position.setX(old_position.x() + _size.x());
     }
     while (old_position.x() >= _size.x() / 2) {
-        old_position[0] -= _size.x();
+        old_position.setX(old_position.x() - _size.x());
     }
     while (old_position.y() < -_size.y() / 2) {
-        old_position[1] += _size.y();
+        old_position.setY(old_position.y() + _size.y());
     }
     while (old_position.y() >= _size.y() / 2) {
-        old_position[1] -= _size.y();
+        old_position.setY(old_position.y() - _size.y());
     }
 }
 

--- a/src/world/world.cpp
+++ b/src/world/world.cpp
@@ -87,6 +87,17 @@ World::enable_wrap_around() {
 void
 World::drawForeground(QPainter *painter, const QRectF &rect) {
     if (!_wraps_around) {
+        /* FIXME : The border does not disappear
+         * The border does not disappear when we disable the wrap_around after
+         * having enabled it before.
+         *
+         * This is because in this branch we make no
+         * effort to erase a former foreGround created to show the borders.
+         *
+         * Is it the responsibility of drawForeground to erase an old Foreground
+         * or should WorldView be aware and redraw background over the border at
+         * each update ?
+         */
         return;
     }
     (void)rect;  // We are not using the inherited parameter

--- a/src/world/world.cpp
+++ b/src/world/world.cpp
@@ -39,6 +39,42 @@ bool
 World::toggle_wrap_around() {
     return (_wraps_around = !_wraps_around);
 }
+
+bool
+World::wrap_around() const {
+    return _wraps_around;
+}
+
+void
+World::set_size(QVector2D new_size) {
+    _size = new_size;
+}
+
+QVector2D
+World::size() const {
+    return _size;
+}
+
+void
+World::fix_position_for_wrap_around(QVector2D &old_position) const {
+    if (!_wraps_around) {
+        return;
+    }
+
+    while (old_position.x() < -_size.x() / 2) {
+        old_position[0] += _size.x();
+    }
+    while (old_position.x() >= _size.x() / 2) {
+        old_position[0] -= _size.x();
+    }
+    while (old_position.y() < -_size.y() / 2) {
+        old_position[1] += _size.y();
+    }
+    while (old_position.y() >= _size.y() / 2) {
+        old_position[1] -= _size.y();
+    }
+}
+
 bool
 World::disable_wrap_around() {
     return (_wraps_around = false);

--- a/src/world/world.h
+++ b/src/world/world.h
@@ -42,7 +42,7 @@ class World : public QGraphicsScene {
     World();
 
     //! Destructor
-    ~World();
+    ~World() override;
 
     //! Render the World for QGraphicsView
     void render();
@@ -52,7 +52,7 @@ class World : public QGraphicsScene {
      * How can we manage ownership ? The method should return a WeakPointer
      */
     template <typename... Ts>
-    const Entity*
+    const Entity *
     add_entity(QString super_type, QString type, Ts &&... params) {
         Entity *p_entity = EntityFactory::make_entity(
             super_type, type, std::forward<Ts>(params)...);
@@ -77,6 +77,24 @@ class World : public QGraphicsScene {
 
     //! Toggle wraps_around and return the new current value
     bool toggle_wrap_around();
+
+    //! Return the current status for wrap_around
+    inline bool wrap_around() const;
+
+    //! Sets arbitrarily the size of the World (useful only with _wraps_around)
+    void set_size(QVector2D new_size);
+
+    //! Return the current size of the World (useful only with _wraps_around)
+    QVector2D size() const;
+
+    /*!
+     * @brief fix_position_for_wrap_around Ensure that old_position is within
+     * the rectangle centered in (0;0) and with dimensions _size, ONLY if
+     * _wraps_around is set
+     * @param [in,out] old_position is the position to be modified in order to
+     * fit the requirement
+     */
+    void fix_position_for_wrap_around(QVector2D &old_position) const;
 
     float time_step() const;
     void set_time_step(float dt);
@@ -111,7 +129,7 @@ class World : public QGraphicsScene {
     QVector2D _size{DEFAULT_WORLD_WIDTH, DEFAULT_WORLD_HEIGHT};
     float _time{0};
     QVector<QSharedPointer<Entity>> _agents{};
-    int _next_id{0}; //!< Next id to assign to Entity
+    int _next_id{0};  //!< Next id to assign to Entity
 
     //! Draw a border around the World rectangle if the world wraps around
     /*! This is an overloaded method, the second parameter is not used.

--- a/src/world/world.h
+++ b/src/world/world.h
@@ -79,7 +79,7 @@ class World : public QGraphicsScene {
     bool toggle_wrap_around();
 
     //! Return the current status for wrap_around
-    inline bool wrap_around() const;
+    bool wrap_around() const;
 
     //! Sets arbitrarily the size of the World (useful only with _wraps_around)
     void set_size(QVector2D new_size);

--- a/src/world/world.h
+++ b/src/world/world.h
@@ -48,11 +48,11 @@ class World : public QGraphicsScene {
     void render();
 
     //! Add an entity to the World
-    /**
+    /** TODO : Manage ownership of return pointer
      * How can we manage ownership ? The method should return a WeakPointer
      */
     template <typename... Ts>
-    const Entity *
+    Entity *
     add_entity(QString super_type, QString type, Ts &&... params) {
         Entity *p_entity = EntityFactory::make_entity(
             super_type, type, std::forward<Ts>(params)...);

--- a/test/test_world.cpp
+++ b/test/test_world.cpp
@@ -29,6 +29,8 @@ class TestWorld : public QObject {
     void test_toggle_vision(void);
     void test_wrap_around(void);
     void test_wrap_around_data(void);
+    void test_vision_wrap_around(void);
+    void test_vision_wrap_around_data(void);
 };
 
 void
@@ -105,139 +107,170 @@ TestWorld::test_toggle_vision(void) {
     QVERIFY(ant->show_vision() == false);
 }
 
-void TestWorld::test_wrap_around_data(void) {
+void
+TestWorld::test_wrap_around_data(void) {
     QTest::addColumn<QVector2D>("world_size");
     QTest::addColumn<QVector2D>("initial_pos");
     QTest::addColumn<QVector2D>("expected_pos");
 
     QTest::newRow("Integer  size -- No work")
-            << QVector2D(640, 480)
-            << QVector2D(-25, 200.3f)
-            << QVector2D(-25, 200.3f);
+        << QVector2D(640, 480) << QVector2D(-25, 200.3f)
+        << QVector2D(-25, 200.3f);
     QTest::newRow("Integer  size -- 1 pass x+")
-            << QVector2D(640, 480)
-            << QVector2D(345.2f, 200.3f)
-            << QVector2D(-294.8f, 200.3f);
+        << QVector2D(640, 480) << QVector2D(345.2f, 200.3f)
+        << QVector2D(-294.8f, 200.3f);
     QTest::newRow("Integer  size -- multiple passes x+")
-            << QVector2D(640, 480)
-            << QVector2D(1049.2f, 200.3f)
-            << QVector2D(-230.8f, 200.3f);
+        << QVector2D(640, 480) << QVector2D(1049.2f, 200.3f)
+        << QVector2D(-230.8f, 200.3f);
     QTest::newRow("Integer  size -- 1 pass x-")
-            << QVector2D(640, 480)
-            << QVector2D(-600.0f, 200.3f)
-            << QVector2D(40.0f, 200.3f);
+        << QVector2D(640, 480) << QVector2D(-600.0f, 200.3f)
+        << QVector2D(40.0f, 200.3f);
     QTest::newRow("Integer  size -- multiple passes x-")
-            << QVector2D(640, 480)
-            << QVector2D(-1240.0f, 200.3f)
-            << QVector2D(40.0f, 200.3f);
+        << QVector2D(640, 480) << QVector2D(-1240.0f, 200.3f)
+        << QVector2D(40.0f, 200.3f);
     QTest::newRow("Integer  size -- 1 pass y+")
-            << QVector2D(640, 480)
-            << QVector2D(-25.0f, 250.3f)
-            << QVector2D(-25.0f, -229.7f);
+        << QVector2D(640, 480) << QVector2D(-25.0f, 250.3f)
+        << QVector2D(-25.0f, -229.7f);
     QTest::newRow("Integer  size -- multiple passes y+")
-            << QVector2D(640, 480)
-            << QVector2D(-25.0f, 899.0f)
-            << QVector2D(-25.0f, -61.0f);
+        << QVector2D(640, 480) << QVector2D(-25.0f, 899.0f)
+        << QVector2D(-25.0f, -61.0f);
     QTest::newRow("Integer  size -- 1 pass y-")
-            << QVector2D(640, 480)
-            << QVector2D(-25.0f, -490.3f)
-            << QVector2D(-25.0f, -10.3f);
+        << QVector2D(640, 480) << QVector2D(-25.0f, -490.3f)
+        << QVector2D(-25.0f, -10.3f);
     QTest::newRow("Integer  size -- multiple passes y-")
-            << QVector2D(640, 480)
-            << QVector2D(-25.0f, -899.0f)
-            << QVector2D(-25.0f, 61.0f);
+        << QVector2D(640, 480) << QVector2D(-25.0f, -899.0f)
+        << QVector2D(-25.0f, 61.0f);
     QTest::newRow("Integer  size -- 1 pass x+, y-")
-            << QVector2D(640, 480)
-            << QVector2D(345.2f, -490.3f)
-            << QVector2D(-294.8f, -10.3f);
+        << QVector2D(640, 480) << QVector2D(345.2f, -490.3f)
+        << QVector2D(-294.8f, -10.3f);
     QTest::newRow("Integer  size -- 1 pass x-, y+")
-            << QVector2D(640, 480)
-            << QVector2D(-600.0f, 250.3f)
-            << QVector2D(40.0f, -229.7f);
+        << QVector2D(640, 480) << QVector2D(-600.0f, 250.3f)
+        << QVector2D(40.0f, -229.7f);
     QTest::newRow("Integer  size -- multiple passes x-, 1 pass y+")
-            << QVector2D(640, 480)
-            << QVector2D(-1240.0f, 250.3f)
-            << QVector2D(40.0f, -229.7f);
+        << QVector2D(640, 480) << QVector2D(-1240.0f, 250.3f)
+        << QVector2D(40.0f, -229.7f);
     QTest::newRow("Integer  size -- 1 pass x-, multiple passes y+")
-            << QVector2D(640, 480)
-            << QVector2D(-600.0f, 899.0f)
-            << QVector2D(40.0f, -61.0f);
+        << QVector2D(640, 480) << QVector2D(-600.0f, 899.0f)
+        << QVector2D(40.0f, -61.0f);
     QTest::newRow("Integer  size -- multiple passes x+, multiple passes y-")
-            << QVector2D(640, 480)
-            << QVector2D(1049.2f, -899.0f)
-            << QVector2D(-230.8f, 61.0f);
+        << QVector2D(640, 480) << QVector2D(1049.2f, -899.0f)
+        << QVector2D(-230.8f, 61.0f);
 
     QTest::newRow("Floating size -- No work")
-            << QVector2D(640.5f, 480.5f)
-            << QVector2D(-25, 200.3f)
-            << QVector2D(-25, 200.3f);
+        << QVector2D(640.5f, 480.5f) << QVector2D(-25, 200.3f)
+        << QVector2D(-25, 200.3f);
     QTest::newRow("Floating size -- 1 pass x+")
-            << QVector2D(640.5f, 480.5f)
-            << QVector2D(345.2f, 200.3f)
-            << QVector2D(-294.8f - 0.5f, 200.3f);
+        << QVector2D(640.5f, 480.5f) << QVector2D(345.2f, 200.3f)
+        << QVector2D(-294.8f - 0.5f, 200.3f);
     QTest::newRow("Floating size -- multiple passes x+")
-            << QVector2D(640.5f, 480.5f)
-            << QVector2D(1049.2f, 200.3f)
-            << QVector2D(-230.8f - 1.0f, 200.3f);
+        << QVector2D(640.5f, 480.5f) << QVector2D(1049.2f, 200.3f)
+        << QVector2D(-230.8f - 1.0f, 200.3f);
     QTest::newRow("Floating size -- 1 pass x-")
-            << QVector2D(640.5f, 480.5f)
-            << QVector2D(-600.0f, 200.3f)
-            << QVector2D(40.0f+0.5f, 200.3f);
+        << QVector2D(640.5f, 480.5f) << QVector2D(-600.0f, 200.3f)
+        << QVector2D(40.0f + 0.5f, 200.3f);
     QTest::newRow("Floating size -- multiple passes x-")
-            << QVector2D(640.5f, 480.5f)
-            << QVector2D(-1240.0f, 200.3f)
-            << QVector2D(40.0f+1.0f, 200.3f);
+        << QVector2D(640.5f, 480.5f) << QVector2D(-1240.0f, 200.3f)
+        << QVector2D(40.0f + 1.0f, 200.3f);
     QTest::newRow("Floating size -- 1 pass y+")
-            << QVector2D(640.5f, 480.5f)
-            << QVector2D(-25.0f, 250.3f)
-            << QVector2D(-25.0f, -229.7f -0.5f);
+        << QVector2D(640.5f, 480.5f) << QVector2D(-25.0f, 250.3f)
+        << QVector2D(-25.0f, -229.7f - 0.5f);
     QTest::newRow("Floating size -- multiple passes y+")
-            << QVector2D(640.5f, 480.5f)
-            << QVector2D(-25.0f, 899.0f)
-            << QVector2D(-25.0f, -61.0f - 1.0f);
+        << QVector2D(640.5f, 480.5f) << QVector2D(-25.0f, 899.0f)
+        << QVector2D(-25.0f, -61.0f - 1.0f);
     QTest::newRow("Floating size -- 1 pass y-")
-            << QVector2D(640.5f, 480.5f)
-            << QVector2D(-25.0f, -490.3f)
-            << QVector2D(-25.0f, -10.3f + 0.5f);
+        << QVector2D(640.5f, 480.5f) << QVector2D(-25.0f, -490.3f)
+        << QVector2D(-25.0f, -10.3f + 0.5f);
     QTest::newRow("Floating size -- multiple passes y-")
-            << QVector2D(640.5f, 480.5f)
-            << QVector2D(-25.0f, -899.0f)
-            << QVector2D(-25.0f, 61.0f + 1.0f);
+        << QVector2D(640.5f, 480.5f) << QVector2D(-25.0f, -899.0f)
+        << QVector2D(-25.0f, 61.0f + 1.0f);
     QTest::newRow("Floating size -- 1 pass x+, y-")
-            << QVector2D(640.5f, 480.5f)
-            << QVector2D(345.2f, -490.3f)
-            << QVector2D(-294.8f -0.5f, -10.3f + 0.5f);
+        << QVector2D(640.5f, 480.5f) << QVector2D(345.2f, -490.3f)
+        << QVector2D(-294.8f - 0.5f, -10.3f + 0.5f);
     QTest::newRow("Floating size -- 1 pass x-, y+")
-            << QVector2D(640.5f, 480.5f)
-            << QVector2D(-600.0f, 250.3f)
-            << QVector2D(40.0f + 0.5f, -229.7f -0.5f);
+        << QVector2D(640.5f, 480.5f) << QVector2D(-600.0f, 250.3f)
+        << QVector2D(40.0f + 0.5f, -229.7f - 0.5f);
     QTest::newRow("Floating size -- multiple passes x-, 1 pass y+")
-            << QVector2D(640.5f, 480.5f)
-            << QVector2D(-1240.0f, 250.3f)
-            << QVector2D(40.0f + 1.0f, -229.7f -0.5f);
+        << QVector2D(640.5f, 480.5f) << QVector2D(-1240.0f, 250.3f)
+        << QVector2D(40.0f + 1.0f, -229.7f - 0.5f);
     QTest::newRow("Floating size -- 1 pass x-, multiple passes y+")
-            << QVector2D(640.5f, 480.5f)
-            << QVector2D(-600.0f, 899.0f)
-            << QVector2D(40.0f + 0.5f, -61.0f - 1.0f);
+        << QVector2D(640.5f, 480.5f) << QVector2D(-600.0f, 899.0f)
+        << QVector2D(40.0f + 0.5f, -61.0f - 1.0f);
     QTest::newRow("Floating size -- multiple passes x+, multiple passes y-")
-            << QVector2D(640.5f, 480.5f)
-            << QVector2D(1049.2f, -899.0f)
-            << QVector2D(-230.8f -1.0f, 61.0f + 1.0f);
+        << QVector2D(640.5f, 480.5f) << QVector2D(1049.2f, -899.0f)
+        << QVector2D(-230.8f - 1.0f, 61.0f + 1.0f);
 }
 
-void TestWorld::test_wrap_around(void) {
+void
+TestWorld::test_wrap_around(void) {
     // Data
     World test_instance;
     QFETCH(QVector2D, world_size);
     QFETCH(QVector2D, initial_pos);
     QFETCH(QVector2D, expected_pos);
 
-
     // Test
     test_instance.set_size(world_size);
     test_instance.enable_wrap_around();
     test_instance.fix_position_for_wrap_around(initial_pos);
     QVERIFY(qFuzzyCompare(initial_pos, expected_pos));
+}
+
+void
+TestWorld::test_vision_wrap_around_data(void) {
+    QTest::addColumn<QVector2D>("world_size");
+    QTest::addColumn<QVector2D>("ant_pos");
+    QTest::addColumn<QRectF>("vision");
+    QTest::addColumn<QPointF>("target_point");
+    QTest::addColumn<bool>("expected");
+
+    // TODO : test corner case when Entity is near the center
+
+    QTest::newRow("Easy point near ant")
+        << QVector2D(640, 480) << QVector2D(315, 220)
+        << QRectF(-50, -50, 100, 100) << QPointF(317, 219.8) << true;
+    QTest::newRow("Easy point on ant")
+        << QVector2D(640, 480) << QVector2D(315, 220)
+        << QRectF(-50, -50, 100, 100) << QPointF(315, 220) << true;
+    QTest::newRow("Easy point same quadrant")
+        << QVector2D(640, 480) << QVector2D(315, 220)
+        << QRectF(-50, -50, 100, 100) << QPointF(34, 2.5) << false;
+    QTest::newRow("Point in other x quadrant, true")
+        << QVector2D(640, 480) << QVector2D(315, 220)
+        << QRectF(-50, -50, 100, 100) << QPointF(-319, 239) << true;
+    QTest::newRow("Point in other x quadrant, false")
+        << QVector2D(640, 480) << QVector2D(315, 220)
+        << QRectF(-50, -50, 100, 100) << QPointF(-24, 239) << false;
+    QTest::newRow("Point in other y quadrant, true")
+        << QVector2D(640, 480) << QVector2D(315, 220)
+        << QRectF(-50, -50, 100, 100) << QPointF(308.0, -236.7) << true;
+    QTest::newRow("Point in other y quadrant, false")
+        << QVector2D(640, 480) << QVector2D(315, 220)
+        << QRectF(-50, -50, 100, 100) << QPointF(308.0, -150.0) << false;
+    QTest::newRow("Point in other xy quadrant, true")
+        << QVector2D(640, 480) << QVector2D(315, 220)
+        << QRectF(-50, -50, 100, 100) << QPointF(-319, -236.7) << true;
+    QTest::newRow("Point in other xy quadrant, false")
+        << QVector2D(640, 480) << QVector2D(315, 220)
+        << QRectF(-50, -50, 100, 100) << QPointF(-24, -150) << false;
+}
+
+void
+TestWorld::test_vision_wrap_around(void) {
+    World test_instance;
+    QFETCH(QVector2D, world_size);
+    QFETCH(QVector2D, ant_pos);
+    QFETCH(QRectF, vision);
+    QFETCH(QPointF, target_point);
+    QFETCH(bool, expected);
+    test_instance.set_size(world_size);
+    test_instance.enable_wrap_around();
+
+    Entity* new_ant = test_instance.add_entity("Living", "Ant", ant_pos);
+    QSharedPointer<QPolygonF> test_vision =
+        QSharedPointer<QPolygonF>(new QPolygonF(vision));
+    new_ant->set_vision(test_vision);
+
+    QCOMPARE(new_ant->is_visible(target_point), expected);
 }
 
 QTEST_MAIN(TestWorld)

--- a/test/test_world.cpp
+++ b/test/test_world.cpp
@@ -181,7 +181,7 @@ void TestWorld::test_wrap_around(void) {
     test_instance.set_size(world_size);
     test_instance.enable_wrap_around();
     test_instance.fix_position_for_wrap_around(initial_pos);
-    QCOMPARE(initial_pos, expected_pos);
+    QVERIFY(qFuzzyCompare(initial_pos, expected_pos));
 }
 
 QTEST_MAIN(TestWorld)

--- a/test/test_world.cpp
+++ b/test/test_world.cpp
@@ -166,7 +166,63 @@ void TestWorld::test_wrap_around_data(void) {
             << QVector2D(640, 480)
             << QVector2D(1049.2f, -899.0f)
             << QVector2D(-230.8f, 61.0f);
-    // TODO : Make the same tests but with Floating point world dimensions
+
+    QTest::newRow("Floating size -- No work")
+            << QVector2D(640.5f, 480.5f)
+            << QVector2D(-25, 200.3f)
+            << QVector2D(-25, 200.3f);
+    QTest::newRow("Floating size -- 1 pass x+")
+            << QVector2D(640.5f, 480.5f)
+            << QVector2D(345.2f, 200.3f)
+            << QVector2D(-294.8f - 0.5f, 200.3f);
+    QTest::newRow("Floating size -- multiple passes x+")
+            << QVector2D(640.5f, 480.5f)
+            << QVector2D(1049.2f, 200.3f)
+            << QVector2D(-230.8f - 1.0f, 200.3f);
+    QTest::newRow("Floating size -- 1 pass x-")
+            << QVector2D(640.5f, 480.5f)
+            << QVector2D(-600.0f, 200.3f)
+            << QVector2D(40.0f+0.5f, 200.3f);
+    QTest::newRow("Floating size -- multiple passes x-")
+            << QVector2D(640.5f, 480.5f)
+            << QVector2D(-1240.0f, 200.3f)
+            << QVector2D(40.0f+1.0f, 200.3f);
+    QTest::newRow("Floating size -- 1 pass y+")
+            << QVector2D(640.5f, 480.5f)
+            << QVector2D(-25.0f, 250.3f)
+            << QVector2D(-25.0f, -229.7f -0.5f);
+    QTest::newRow("Floating size -- multiple passes y+")
+            << QVector2D(640.5f, 480.5f)
+            << QVector2D(-25.0f, 899.0f)
+            << QVector2D(-25.0f, -61.0f - 1.0f);
+    QTest::newRow("Floating size -- 1 pass y-")
+            << QVector2D(640.5f, 480.5f)
+            << QVector2D(-25.0f, -490.3f)
+            << QVector2D(-25.0f, -10.3f + 0.5f);
+    QTest::newRow("Floating size -- multiple passes y-")
+            << QVector2D(640.5f, 480.5f)
+            << QVector2D(-25.0f, -899.0f)
+            << QVector2D(-25.0f, 61.0f + 1.0f);
+    QTest::newRow("Floating size -- 1 pass x+, y-")
+            << QVector2D(640.5f, 480.5f)
+            << QVector2D(345.2f, -490.3f)
+            << QVector2D(-294.8f -0.5f, -10.3f + 0.5f);
+    QTest::newRow("Floating size -- 1 pass x-, y+")
+            << QVector2D(640.5f, 480.5f)
+            << QVector2D(-600.0f, 250.3f)
+            << QVector2D(40.0f + 0.5f, -229.7f -0.5f);
+    QTest::newRow("Floating size -- multiple passes x-, 1 pass y+")
+            << QVector2D(640.5f, 480.5f)
+            << QVector2D(-1240.0f, 250.3f)
+            << QVector2D(40.0f + 1.0f, -229.7f -0.5f);
+    QTest::newRow("Floating size -- 1 pass x-, multiple passes y+")
+            << QVector2D(640.5f, 480.5f)
+            << QVector2D(-600.0f, 899.0f)
+            << QVector2D(40.0f + 0.5f, -61.0f - 1.0f);
+    QTest::newRow("Floating size -- multiple passes x+, multiple passes y-")
+            << QVector2D(640.5f, 480.5f)
+            << QVector2D(1049.2f, -899.0f)
+            << QVector2D(-230.8f -1.0f, 61.0f + 1.0f);
 }
 
 void TestWorld::test_wrap_around(void) {

--- a/test/test_world.cpp
+++ b/test/test_world.cpp
@@ -27,6 +27,8 @@ class TestWorld : public QObject {
     void add_food(void);
     void add_ant(void);
     void test_toggle_vision(void);
+    void test_wrap_around(void);
+    void test_wrap_around_data(void);
 };
 
 void
@@ -38,18 +40,18 @@ TestWorld::add_food(void) {
     QVERIFY(test_instance.add_entity("Inert", "Food") != nullptr);
     QVERIFY(test_instance.add_entity("Inert", "Food", QVector2D(22, 35)) !=
             nullptr);
-    QVERIFY(test_instance.add_entity("Inert", "Food", QVector2D(-3.2, 21),
-                                     QVector2D(24.1, 1e-2)) != nullptr);
+    QVERIFY(test_instance.add_entity("Inert", "Food", QVector2D(-3.2f, 21),
+                                     QVector2D(24.1f, 1e-2f)) != nullptr);
     QVERIFY(test_instance.add_entity("inert", "food") != nullptr);
     QVERIFY(test_instance.add_entity("inert", "food", QVector2D(22, 35)) !=
             nullptr);
-    QVERIFY(test_instance.add_entity("inert", "food", QVector2D(-3.2, 21),
-                                     QVector2D(24.1, 1e-2)) != nullptr);
+    QVERIFY(test_instance.add_entity("inert", "food", QVector2D(-3.2f, 21),
+                                     QVector2D(24.1f, 1e-2f)) != nullptr);
     QVERIFY(test_instance.add_entity("InErt", "FooD") != nullptr);
     QVERIFY(test_instance.add_entity("InErt", "FooD", QVector2D(22, 35)) !=
             nullptr);
-    QVERIFY(test_instance.add_entity("InErt", "FooD", QVector2D(-3.2, 21),
-                                     QVector2D(24.1, 1e-2)) != nullptr);
+    QVERIFY(test_instance.add_entity("InErt", "FooD", QVector2D(-3.2f, 21),
+                                     QVector2D(24.1f, 1e-2f)) != nullptr);
 
     // Test exception in case of bad type and super type
     QVERIFY_EXCEPTION_THROWN(test_instance.add_entity("fdasdfas", "food"),
@@ -67,18 +69,18 @@ TestWorld::add_ant(void) {
     QVERIFY(test_instance.add_entity("Living", "Ant") != nullptr);
     QVERIFY(test_instance.add_entity("Living", "Ant", QVector2D(22, 35)) !=
             nullptr);
-    QVERIFY(test_instance.add_entity("Living", "Ant", QVector2D(-3.2, 21),
-                                     QVector2D(24.1, 1e-2)) != nullptr);
+    QVERIFY(test_instance.add_entity("Living", "Ant", QVector2D(-3.2f, 21),
+                                     QVector2D(24.1f, 1e-2f)) != nullptr);
     QVERIFY(test_instance.add_entity("living", "ant") != nullptr);
     QVERIFY(test_instance.add_entity("living", "ant", QVector2D(22, 35)) !=
             nullptr);
-    QVERIFY(test_instance.add_entity("living", "ant", QVector2D(-3.2, 21),
-                                     QVector2D(24.1, 1e-2)) != nullptr);
+    QVERIFY(test_instance.add_entity("living", "ant", QVector2D(-3.2f, 21),
+                                     QVector2D(24.1f, 1e-2f)) != nullptr);
     QVERIFY(test_instance.add_entity("liVinG", "aNt") != nullptr);
     QVERIFY(test_instance.add_entity("liVinG", "aNt", QVector2D(22, 35)) !=
             nullptr);
-    QVERIFY(test_instance.add_entity("liVinG", "aNt", QVector2D(-3.2, 21),
-                                     QVector2D(24.1, 1e-2)) != nullptr);
+    QVERIFY(test_instance.add_entity("liVinG", "aNt", QVector2D(-3.2f, 21),
+                                     QVector2D(24.1f, 1e-2f)) != nullptr);
 
     // Test exception in case of bad type and super type
     QVERIFY_EXCEPTION_THROWN(test_instance.add_entity("fdasdfas", "ant"),
@@ -87,11 +89,10 @@ TestWorld::add_ant(void) {
                              FactoryFailure);
 }
 
-void TestWorld::test_toggle_vision(void) {
+void
+TestWorld::test_toggle_vision(void) {
     // Data
     World test_instance;
-
-    // Test case insensitivity and passing arguments
     const Entity* ant = test_instance.add_entity("Living", "Ant");
 
     test_instance.enable_all_visions();
@@ -102,6 +103,85 @@ void TestWorld::test_toggle_vision(void) {
     QVERIFY(ant->show_vision() == true);
     test_instance.toggle_all_visions();
     QVERIFY(ant->show_vision() == false);
+}
+
+void TestWorld::test_wrap_around_data(void) {
+    QTest::addColumn<QVector2D>("world_size");
+    QTest::addColumn<QVector2D>("initial_pos");
+    QTest::addColumn<QVector2D>("expected_pos");
+
+    QTest::newRow("Integer  size -- No work")
+            << QVector2D(640, 480)
+            << QVector2D(-25, 200.3f)
+            << QVector2D(-25, 200.3f);
+    QTest::newRow("Integer  size -- 1 pass x+")
+            << QVector2D(640, 480)
+            << QVector2D(345.2f, 200.3f)
+            << QVector2D(-294.8f, 200.3f);
+    QTest::newRow("Integer  size -- multiple passes x+")
+            << QVector2D(640, 480)
+            << QVector2D(1049.2f, 200.3f)
+            << QVector2D(-230.8f, 200.3f);
+    QTest::newRow("Integer  size -- 1 pass x-")
+            << QVector2D(640, 480)
+            << QVector2D(-600.0f, 200.3f)
+            << QVector2D(40.0f, 200.3f);
+    QTest::newRow("Integer  size -- multiple passes x-")
+            << QVector2D(640, 480)
+            << QVector2D(-1240.0f, 200.3f)
+            << QVector2D(40.0f, 200.3f);
+    QTest::newRow("Integer  size -- 1 pass y+")
+            << QVector2D(640, 480)
+            << QVector2D(-25.0f, 250.3f)
+            << QVector2D(-25.0f, -229.7f);
+    QTest::newRow("Integer  size -- multiple passes y+")
+            << QVector2D(640, 480)
+            << QVector2D(-25.0f, 899.0f)
+            << QVector2D(-25.0f, -61.0f);
+    QTest::newRow("Integer  size -- 1 pass y-")
+            << QVector2D(640, 480)
+            << QVector2D(-25.0f, -490.3f)
+            << QVector2D(-25.0f, -10.3f);
+    QTest::newRow("Integer  size -- multiple passes y-")
+            << QVector2D(640, 480)
+            << QVector2D(-25.0f, -899.0f)
+            << QVector2D(-25.0f, 61.0f);
+    QTest::newRow("Integer  size -- 1 pass x+, y-")
+            << QVector2D(640, 480)
+            << QVector2D(345.2f, -490.3f)
+            << QVector2D(-294.8f, -10.3f);
+    QTest::newRow("Integer  size -- 1 pass x-, y+")
+            << QVector2D(640, 480)
+            << QVector2D(-600.0f, 250.3f)
+            << QVector2D(40.0f, -229.7f);
+    QTest::newRow("Integer  size -- multiple passes x-, 1 pass y+")
+            << QVector2D(640, 480)
+            << QVector2D(-1240.0f, 250.3f)
+            << QVector2D(40.0f, -229.7f);
+    QTest::newRow("Integer  size -- 1 pass x-, multiple passes y+")
+            << QVector2D(640, 480)
+            << QVector2D(-600.0f, 899.0f)
+            << QVector2D(40.0f, -61.0f);
+    QTest::newRow("Integer  size -- multiple passes x+, multiple passes y-")
+            << QVector2D(640, 480)
+            << QVector2D(1049.2f, -899.0f)
+            << QVector2D(-230.8f, 61.0f);
+    // TODO : Make the same tests but with Floating point world dimensions
+}
+
+void TestWorld::test_wrap_around(void) {
+    // Data
+    World test_instance;
+    QFETCH(QVector2D, world_size);
+    QFETCH(QVector2D, initial_pos);
+    QFETCH(QVector2D, expected_pos);
+
+
+    // Test
+    test_instance.set_size(world_size);
+    test_instance.enable_wrap_around();
+    test_instance.fix_position_for_wrap_around(initial_pos);
+    QCOMPARE(initial_pos, expected_pos);
 }
 
 QTEST_MAIN(TestWorld)


### PR DESCRIPTION
Implement wrap_around for the vision and the position of Entities.

Add a mapping to toggle the wrap_around during execution